### PR TITLE
fix(jumper): the link do not jumper to the repository

### DIFF
--- a/docs/zh-cn/best-practices/cts/index.md
+++ b/docs/zh-cn/best-practices/cts/index.md
@@ -12,9 +12,9 @@
 
 本章节包含以下最佳实践：
 
-* [使用Terraform创建CTS数据跟踪器](./data_tracker.md) - 通过数据跟踪器实现云资源操作的自动记录和存储，支持安全审计、合规监控等功能，提供完整的Terraform配置和参数说明。
-* [使用Terraform创建CTS通知](./notification.md) - 通过CTS通知实现云资源操作的实时监控和告警，支持安全事件监控、异常操作告警等功能，提供完整的Terraform配置和参数说明。
-* [使用Terraform创建CTS系统追踪器](./system_tracker.md) - 通过系统追踪器实现云资源操作的自动记录和存储，支持安全审计、合规监控等功能，提供完整的Terraform配置和参数说明。
+* [使用Terraform创建CTS数据跟踪器](data_tracker.md) - 通过数据跟踪器实现云资源操作的自动记录和存储，支持安全审计、合规监控等功能，提供完整的Terraform配置和参数说明。
+* [使用Terraform创建CTS通知](notification.md) - 通过CTS通知实现云资源操作的实时监控和告警，支持安全事件监控、异常操作告警等功能，提供完整的Terraform配置和参数说明。
+* [使用Terraform创建CTS系统追踪器](system_tracker.md) - 通过系统追踪器实现云资源操作的自动记录和存储，支持安全审计、合规监控等功能，提供完整的Terraform配置和参数说明。
 
 ## 参考资料
 

--- a/docs/zh-cn/best-practices/fgs/index.md
+++ b/docs/zh-cn/best-practices/fgs/index.md
@@ -12,9 +12,9 @@
 
 本章节包含以下最佳实践：
 
-* [使用FunctionGraph创建CTS触发器](./cts_trigger.md) - 通过CTS触发器实现云资源操作监控和响应，支持安全审计、合规监控、自动化运维等功能，提供完整的Terraform配置和参数说明。
-* [使用FunctionGraph创建EG触发器](./eg_trigger.md) - 通过EG触发器实现事件驱动的图像处理，支持OBS文件上传时自动生成缩略图，提供完整的Terraform配置和参数说明。
-* [使用FunctionGraph创建定时触发器](./timer_trigger.md) - 通过定时触发器实现周期性任务执行，支持Cron表达式和固定间隔两种调度方式，提供完整的Terraform配置和参数说明。
+* [使用FunctionGraph创建CTS触发器](cts_trigger.md) - 通过CTS触发器实现云资源操作监控和响应，支持安全审计、合规监控、自动化运维等功能，提供完整的Terraform配置和参数说明。
+* [使用FunctionGraph创建EG触发器](eg_trigger.md) - 通过EG触发器实现事件驱动的图像处理，支持OBS文件上传时自动生成缩略图，提供完整的Terraform配置和参数说明。
+* [使用FunctionGraph创建定时触发器](timer_trigger.md) - 通过定时触发器实现周期性任务执行，支持Cron表达式和固定间隔两种调度方式，提供完整的Terraform配置和参数说明。
 
 ## 参考资料
 

--- a/docs/zh-cn/introductions/prepare_before_deploy.md
+++ b/docs/zh-cn/introductions/prepare_before_deploy.md
@@ -4,7 +4,7 @@
 
 ## 安装Terraform
 
-Terraform的安装方式因操作系统而异，我们提供了详细的安装指南文档：[如何安装Terraform](./how_to_install_terraform.md)
+Terraform的安装方式因操作系统而异，我们提供了详细的安装指南文档：[如何安装Terraform](how_to_install_terraform.md)
 请根据文档的指引进行操作。
 
 ## 准备部署脚本的工作目录


### PR DESCRIPTION
The old expression `./xxx` will jumper to the Github repository page, not just the Gitbook page.